### PR TITLE
pwrite: measure effect of concurrency

### DIFF
--- a/pwrite/Makefile
+++ b/pwrite/Makefile
@@ -3,6 +3,7 @@
 SUBDIRECTORIES := $(shell ls -d */)
 
 all:
+	mkdir -p scratch_output
 	for DIR in $(SUBDIRECTORIES) ; do $(MAKE) -C $$DIR all ; done
 
 run:
@@ -10,4 +11,4 @@ run:
 
 clean:
 	for DIR in $(SUBDIRECTORIES) ; do $(MAKE) -C $$DIR clean ; done
-	rm -f scratch_output
+	rm -rf scratch_output

--- a/pwrite/Makefile
+++ b/pwrite/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all run clean
 
-SUBDIRECTORIES := $(shell ls -d */)
+SUBDIRECTORIES := $(shell ls -d */ | grep -v scratch)
 
 all:
 	mkdir -p scratch_output

--- a/pwrite/ocaml/_tags
+++ b/pwrite/ocaml/_tags
@@ -2,4 +2,5 @@
 <*>: package(lwt.preemptive)
 <*>: package(core)
 <*>: package(mtime.os)
+<*>: package(cmdliner)
 <*>: thread

--- a/pwrite/ocaml/benchmark_osx_pwrite.ml
+++ b/pwrite/ocaml/benchmark_osx_pwrite.ml
@@ -14,6 +14,7 @@ module type IO = sig
 
   val return : 'a -> 'a t
   val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+  val join : unit t list -> unit t
 
   val init : unit -> unit
   val run : 'a t -> 'a
@@ -32,12 +33,33 @@ module Make
     with type 'a io := 'a IO.t
     and type buffer := Buffer.t) : BENCHMARK = struct
 
-  let time_configured buffer_size repetitions =
-    let file = "../../scratch_output" in
+  let time_configured buffer_size repetitions concurrency =
+    let files =
+      Array.init concurrency
+        (Printf.sprintf "../../scratch_output/thread-%i")
+    in
 
     (* Closed on process exit. *)
-    let fd = Unix.(openfile file [O_WRONLY; O_CREAT; O_TRUNC] 0o644) in
-    let buffer = Buffer.allocate buffer_size in
+    let fds =
+      Array.init concurrency (fun n ->
+        Unix.(openfile files.(n) [O_WRONLY; O_CREAT; O_TRUNC] 0o644))
+    in
+
+    let buffers =
+      Array.init concurrency (fun _ -> Buffer.allocate buffer_size) in
+
+    let thread n =
+      let open IO in
+      let rec repeat = function
+        | n' when n' <= 0 -> return ()
+        | n' ->
+          Pwrite.pwrite fds.(n) buffers.(n) buffer_size 0L
+          >>= fun written ->
+          assert (written = buffer_size);
+          repeat (n' - 1)
+      in
+      repeat repetitions
+    in
 
     IO.init ();
     IO.run
@@ -45,20 +67,13 @@ module Make
         let open IO in
 
         let start = Mtime.counter () in
-        let rec repeat = function
-          | n when n <= 0 -> return ()
-          | n ->
-            Pwrite.pwrite fd buffer buffer_size 0L
-            >>= fun written ->
-            assert (written = buffer_size);
-            repeat (n - 1)
-        in
-        repeat repetitions
-        >>= fun () ->
+        let threads = Array.init concurrency thread |> Array.to_list in
+        IO.join threads >>= fun () ->
         let elapsed = Mtime.count start in
 
         let elapsed = Mtime.to_us elapsed /. (float_of_int repetitions) in
         Printf.printf "%9.02f µs\n" elapsed;
+
         IO.return ()
       end
 
@@ -77,8 +92,14 @@ module Make
           ~env:(env_var "BENCHMARK_REPETITIONS"))
     in
 
+    let concurrency =
+      Arg.(value & opt int 1 &
+        info ["concurrency"] ~docv:"N"
+          ~env:(env_var "BENCHMARK_CONCURRENCY"))
+    in
+
     let command =
-      Term.(const time_configured $ buffer_size $ repetitions),
+      Term.(const time_configured $ buffer_size $ repetitions $ concurrency),
       Term.info "pwrite"
     in
 
@@ -90,6 +111,7 @@ module Use_blocking_io : IO with type 'a t = 'a = struct
 
   let return x = x
   let (>>=) x f = f x
+  let join _ = ()
 
   let init () = ()
   let run x = x
@@ -100,9 +122,64 @@ module Use_lwt : IO with type 'a t = 'a Lwt.t = struct
 
   let return = Lwt.return
   let (>>=) = Lwt.bind
+  let join = Lwt.join
 
   let init () = Lwt_engine.(set (new Lwt_engine.Versioned.libev_2 ()))
   let run = Lwt_main.run
+end
+
+module Use_threaded_cps = struct
+  type 'a t = ('a -> unit) -> unit
+
+  let return x = fun k -> k x
+  let (>>=) f g = fun k -> f (fun x -> g x k)
+  let join fs =
+    fun k ->
+      let remaining = ref (List.length fs) in
+      if !remaining = 0 then k ()
+      else
+        let k' () =
+          if !remaining = 1 then k ()
+          else remaining := !remaining - 1
+        in
+        List.iter (fun f -> f k') fs
+
+  let init () = ()
+
+  let notifications : (unit -> unit) list ref = ref []
+  let notification_mutex = Mutex.create ()
+  let notification_condition = Condition.create ()
+
+  let notify g =
+    Mutex.lock notification_mutex;
+    notifications := !notifications @ [g];
+    Condition.signal notification_condition;
+    Mutex.unlock notification_mutex
+
+  let run f =
+    let result = ref None in
+    f (fun x -> result := Some x);
+    Mutex.lock notification_mutex;
+    let rec loop () =
+      match !result with
+      | Some x ->
+        Mutex.unlock notification_mutex;
+        x
+      | None ->
+        match !notifications with
+        | [] ->
+          Condition.wait notification_condition notification_mutex;
+          loop ()
+        | g::more ->
+          notifications := more;
+          Mutex.unlock notification_mutex;
+          g ();
+          Mutex.lock notification_mutex;
+          loop ()
+    in
+    let result = loop () in
+    Mutex.unlock notification_mutex;
+    result
 end
 
 module Ctypes_buffer : BUFFER with type t = unit Ctypes.ptr = struct

--- a/pwrite/ocaml/benchmark_osx_pwrite.ml
+++ b/pwrite/ocaml/benchmark_osx_pwrite.ml
@@ -71,8 +71,18 @@ module Make
         IO.join threads >>= fun () ->
         let elapsed = Mtime.count start in
 
-        let elapsed = Mtime.to_us elapsed /. (float_of_int repetitions) in
-        Printf.printf "%9.02f µs\n" elapsed;
+        let per_byte =
+          Mtime.to_ns elapsed
+          /. (float_of_int buffer_size)
+          /. (float_of_int repetitions)
+          /. (float_of_int concurrency)
+        in
+        let per_second =
+          (float_of_int (buffer_size * repetitions * concurrency))
+          /. (Mtime.to_s elapsed)
+          /. 1024. /. 1024.
+        in
+        Printf.printf "%9.02f ns/B (%.0f MB/sec)\n" per_byte per_second;
 
         IO.return ()
       end

--- a/pwrite/ocaml/benchmark_osx_pwrite.ml
+++ b/pwrite/ocaml/benchmark_osx_pwrite.ml
@@ -157,7 +157,9 @@ module Use_lwt : IO with type 'a t = 'a Lwt.t = struct
   let (>>=) = Lwt.bind
   let join = Lwt.join
 
-  let init () = Lwt_engine.(set (new Lwt_engine.Versioned.libev_2 ()))
+  let init () =
+    Lwt_engine.(set
+      (new Lwt_engine.Versioned.libev_2 ~backend:Ev_backend.kqueue ()))
   let run = Lwt_main.run
 end
 

--- a/pwrite/ocaml/benchmark_osx_pwrite.ml
+++ b/pwrite/ocaml/benchmark_osx_pwrite.ml
@@ -43,7 +43,10 @@ module Make
         (Printf.sprintf "../../scratch_output/thread-%i")
     in
 
-    (* Closed on process exit. *)
+    (* Closed on process exit.
+
+       In particular, the time needed to close the fds is not counted in the
+       performance measurement. *)
     let fds =
       Array.init concurrency (fun n ->
         Unix.(openfile files.(n) [O_WRONLY; O_CREAT; O_TRUNC] 0o644))


### PR DESCRIPTION
This PR mainly adds the ability to run `pwrite` concurrently.

Results are in nanoseconds per byte. The columns are used for thread counts, from 1 to 64. For blocking implementations (`Core`, `Unistd (blocking)`, and `Unistd (Lwt unthreaded)`), "threads" degenerate, and are run in series.

I ran the benchmarks for "realistic" buffer sizes of 1K, 4K, and 16K, and then searched for some large buffer size at which threaded implementations have a clear advantage when multiple threads are available.

<br/>

```
--buffer-size 1024 --repetitions 4096

BENCHMARK          THREADS: 1       2       4       8      16      32      64

Core                       3.58    2.81    3.21    2.90    2.86    3.03    2.71
Unistd (blocking)          3.71    3.17    3.66    3.36    3.36    3.44    3.10
Unistd (Lwt unthreaded)    5.90    5.39    4.45    4.74    4.74    4.41    4.39

Thread                    16.31   12.50   17.29   19.62   19.89   20.20   20.62
Lwt_preemptive            20.88   17.58   17.70   17.94   17.88   18.00   18.33
Unistd (Lwt threaded)     25.33   14.11   12.09   12.08   12.08   12.59   12.23
```

<br/>

```
--buffer-size 4096 --repetitions 1024

BENCHMARK          THREADS: 1       2       4       8      16      32      64

Core                       2.10    1.74    1.40    1.63    1.52    1.71    1.39
Unistd (blocking)          1.53    1.78    1.48    1.56    1.96    1.60    1.80
Unistd (Lwt unthreaded)    1.76    2.14    2.35    1.89    2.19    2.13    2.36

Thread                     4.88    4.10    4.54    5.27    5.24    5.36    5.57
Lwt_preemptive             6.53    4.92    4.75    4.73    4.42    4.50    4.47
Unistd (Lwt threaded)      6.84    4.26    3.24    3.05    3.03    3.16    3.15
```

<br/>

```
--buffer-size 16384 --repetitions 256

BENCHMARK          THREADS: 1       2       4       8      16      32      64

Core                       0.73    0.63    0.54    0.61    0.53    0.60    0.55
Unistd (blocking)          0.55    0.52    0.86    0.54    0.58    0.60    0.60
Unistd (Lwt unthreaded)    0.62    1.13    0.60    0.85    0.76    0.77    0.60

Thread                     1.40    1.80    1.19    1.46    1.44    1.44    1.47
Lwt_preemptive             1.78    1.35    1.23    1.29    1.26    1.29    1.26
Unistd (Lwt threaded)      2.12    2.02    0.76    0.83    0.85    0.97    0.96
```

<br/><br/>

A big-buffer-size run:

```
--buffer-size 262144 --repetitions 16

BENCHMARK          THREADS: 1       2       4       8      16      32      64

Core                       0.31    0.30    0.29    0.38    0.35    0.35    0.31
Unistd (blocking)          0.27    0.26    0.28    0.29    0.35    0.41    0.35
Unistd (Lwt unthreaded)    0.43    0.29    0.28    0.44    0.37    0.36    0.38

Thread                     0.40    0.24    0.16    0.16    0.15    0.21    0.20
Lwt_preemptive             0.42    0.27    0.17    0.16    0.21    0.21    0.18
Unistd (Lwt threaded)      0.59    0.26    0.16    0.14    0.14    0.16    0.15
```

<br/>

On my system, threaded I/O was starting to become relatively faster at buffer sizes of around 64K, with 16+ threads, and was definitively faster at 1M with 2+ threads.
