### PR TITLE
C pwrite benchmarks

### DIFF
--- a/pwrite/c/Makefile
+++ b/pwrite/c/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all run clean
+
+SUBDIRECTORIES := $(shell ls -d */)
+
+all:
+	for DIR in $(SUBDIRECTORIES) ; do $(MAKE) -C $$DIR all ; done
+
+run:
+	@for DIR in $(SUBDIRECTORIES) ; do $(MAKE) -C $$DIR run ; done
+
+clean:
+	for DIR in $(SUBDIRECTORIES) ; do $(MAKE) -C $$DIR clean ; done

--- a/pwrite/c/Makefile.system
+++ b/pwrite/c/Makefile.system
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/benchmark_osx_pwrite.h
+++ b/pwrite/c/benchmark_osx_pwrite.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <mach/mach_time.h>
+
+size_t benchmark_buffer_size = 4096;
+int benchmark_repetitions = 65536;
+int benchmark_concurrency = 1;
+int benchmark_stride = 1;
+
+int benchmark_parse_integer(const char *s) {
+    errno = 0;
+    char *end;
+    int result = strtol(s, &end, 0);
+
+    if (errno == ERANGE) {
+        perror("strtol");
+        exit(1);
+    }
+
+    if (end == s || *end != '\0') {
+        fprintf(stderr, "Failure: strtol\n");
+        exit(1);
+    }
+
+    return result;
+}
+
+const char* benchmark_parameter(int argc, char **argv, int argument_index,
+                                const char *environment_variable) {
+    if (argc > argument_index)
+        return argv[argument_index];
+    else
+        return getenv(environment_variable);
+}
+
+bool benchmark_integer_parameter(int argc, char **argv, int argument_index,
+                                 const char *environment_variable,
+                                 int *result) {
+    const char *value =
+        benchmark_parameter(argc, argv, argument_index, environment_variable);
+    if (value == NULL)
+        return false;
+
+    *result = benchmark_parse_integer(value);
+    return true;
+}
+
+void benchmark_parameters(int argc, char **argv) {
+    int buffer_size;
+    bool result =
+        benchmark_integer_parameter(argc, argv, 1, "BENCHMARK_BUFFER_SIZE",
+                                    &buffer_size);
+    if (result)
+        benchmark_buffer_size = buffer_size;
+
+    benchmark_integer_parameter(argc, argv, 2, "BENCHMARK_REPETITIONS",
+                                &benchmark_repetitions);
+    benchmark_integer_parameter(argc, argv, 3, "BENCHMARK_CONCURRENCY",
+                                &benchmark_concurrency);
+
+    const char *access_pattern =
+        benchmark_parameter(argc, argv, 4, "BENCHMARK_ACCESS_PATTERN");
+    if (access_pattern != NULL) {
+        if (strcmp(access_pattern, "in-place") == 0)
+            benchmark_stride = 0;
+    }
+}
+
+const char *benchmark_output_directory = "../../scratch_output";
+
+// The benchmarks don't bother deallocating the strings returned from this
+// function.
+const char* benchmark_file(int n) {
+    char *s = malloc(strlen(benchmark_output_directory) + 10);
+    sprintf(s, "%s/thread-%i", benchmark_output_directory, n);
+    return s;
+}
+
+void benchmark_show_result(uint64_t start, uint64_t end) {
+    mach_timebase_info_data_t scale;
+    mach_timebase_info(&scale);
+
+    double elapsed_ns = (double)(end - start) * scale.numer / scale.denom;
+    double bytes =
+        benchmark_buffer_size * benchmark_repetitions * benchmark_concurrency;
+
+    double per_byte = elapsed_ns / bytes;
+    double per_second = (bytes / 1024 / 1024) / (elapsed_ns / 1e9);
+
+    printf("%9.02f ns/B (%.0f MB/sec)\n", per_byte, per_second);
+}
+
+void* benchmark_malloc(size_t size) {
+    void *result = malloc(size);
+    if (result == NULL) {
+        perror("malloc");
+        exit(1);
+    }
+    return result;
+}
+
+size_t benchmark_offset(int repetition) {
+    return
+        (repetition * benchmark_buffer_size * benchmark_stride)
+            % (16 * 1024 * 1024);
+}

--- a/pwrite/c/blocking/Makefile
+++ b/pwrite/c/blocking/Makefile
@@ -1,13 +1,1 @@
-.PHONY: all run clean
-
-all: pwrite
-
-pwrite: pwrite.c ../benchmark_osx_pwrite.h
-	cc -o pwrite pwrite.c
-
-run:
-	@echo `pwd`
-	@./pwrite
-
-clean:
-	rm -f pwrite
+../Makefile.system

--- a/pwrite/c/blocking/Makefile
+++ b/pwrite/c/blocking/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/blocking/pwrite.c
+++ b/pwrite/c/blocking/pwrite.c
@@ -1,0 +1,48 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    char *buffer;
+    int fd;
+} per_file;
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        state[thread].buffer = benchmark_malloc(benchmark_buffer_size);
+
+        state[thread].fd =
+            open(benchmark_file(thread), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (state[thread].fd == -1) {
+            perror("fopen");
+            exit(1);
+        }
+    }
+
+    uint64_t start = mach_absolute_time();
+
+    for (int repetition = 0; repetition < benchmark_repetitions; ++repetition) {
+        for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+            ssize_t written =
+                pwrite(state[thread].fd, state[thread].buffer,
+                       benchmark_buffer_size, benchmark_offset(repetition));
+            if (written == -1) {
+                perror("pwrite");
+                exit(1);
+            }
+            assert(written == benchmark_buffer_size);
+        }
+    }
+
+    uint64_t end = mach_absolute_time();
+    benchmark_show_result(start, end);
+
+    return 0;
+}

--- a/pwrite/c/libdispatch-block-queue/Makefile
+++ b/pwrite/c/libdispatch-block-queue/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/libdispatch-block-queue/pwrite.c
+++ b/pwrite/c/libdispatch-block-queue/pwrite.c
@@ -1,0 +1,83 @@
+#include <assert.h>
+#include <dispatch/dispatch.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    char *buffer;
+    int fd;
+    int repetition;
+} per_file;
+
+dispatch_queue_t queue;
+int completed = 0;
+uint64_t start;
+
+void submit_pwrite_request(per_file *state);
+void pwrite_callback(per_file *state);
+void pwrite_completed(per_file *state);
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        state[thread].buffer = benchmark_malloc(benchmark_buffer_size);
+
+        state[thread].fd =
+            open(benchmark_file(thread), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (state[thread].fd == -1) {
+            perror("fopen");
+            exit(1);
+        }
+
+        state[thread].repetition = 0;
+    }
+
+    queue = dispatch_queue_create("benchmark", DISPATCH_QUEUE_CONCURRENT);
+
+    start = mach_absolute_time();
+
+    for (int thread = 0; thread < benchmark_concurrency; ++thread)
+        submit_pwrite_request(&state[thread]);
+
+    dispatch_main();
+
+    // This should be unreachable.
+    return 0;
+}
+
+// Runs in the main thread after each pwrite call completes.
+void pwrite_completed(per_file *state) {
+    ++state->repetition;
+    if (state->repetition < benchmark_repetitions)
+        submit_pwrite_request(state);
+    else {
+        ++completed;
+        if (completed >= benchmark_concurrency) {
+            uint64_t end = mach_absolute_time();
+            benchmark_show_result(start, end);
+            exit(0);
+        }
+    }
+}
+
+void submit_pwrite_request(per_file *state) {
+    dispatch_async_f(queue, state, (dispatch_function_t)pwrite_callback);
+}
+
+void pwrite_callback(per_file *state) {
+    ssize_t written =
+        pwrite(state->fd, state->buffer, benchmark_buffer_size,
+               benchmark_offset(state->repetition));
+    if (written == -1) {
+        perror("pwrite");
+        exit(1);
+    }
+    assert(written == benchmark_buffer_size);
+
+    dispatch_async_f(dispatch_get_main_queue(), state,
+                     (dispatch_function_t)pwrite_completed);
+}

--- a/pwrite/c/libdispatch-block/Makefile
+++ b/pwrite/c/libdispatch-block/Makefile
@@ -1,13 +1,1 @@
-.PHONY: all run clean
-
-all: pwrite
-
-pwrite: pwrite.c ../benchmark_osx_pwrite.h
-	cc -o pwrite pwrite.c
-
-run:
-	@echo `pwd`
-	@./pwrite
-
-clean:
-	rm -f pwrite
+../Makefile.system

--- a/pwrite/c/libdispatch-block/Makefile
+++ b/pwrite/c/libdispatch-block/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/libdispatch-block/pwrite.c
+++ b/pwrite/c/libdispatch-block/pwrite.c
@@ -1,0 +1,74 @@
+#include <assert.h>
+#include <dispatch/dispatch.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    char *buffer;
+    int fd;
+    int repetition;
+} per_file;
+
+dispatch_queue_t queue;
+int completed = 0;
+
+void submit_pwrite_request(per_file *state);
+void pwrite_callback(per_file *state);
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        state[thread].buffer = benchmark_malloc(benchmark_buffer_size);
+
+        state[thread].fd =
+            open(benchmark_file(thread), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (state[thread].fd == -1) {
+            perror("fopen");
+            exit(1);
+        }
+
+        state[thread].repetition = 0;
+    }
+
+    queue = dispatch_queue_create("benchmark", DISPATCH_QUEUE_CONCURRENT);
+
+    uint64_t start = mach_absolute_time();
+
+    for (int thread = 0; thread < benchmark_concurrency; ++thread)
+        submit_pwrite_request(&state[thread]);
+
+    // This is not a legitimate way to wait for the work to complete, but it is
+    // simple and works.
+    while (completed < benchmark_concurrency)
+        continue;
+
+    uint64_t end = mach_absolute_time();
+    benchmark_show_result(start, end);
+
+    return 0;
+}
+
+void submit_pwrite_request(per_file *state) {
+    dispatch_async_f(queue, state, (dispatch_function_t)pwrite_callback);
+}
+
+void pwrite_callback(per_file *state) {
+    ssize_t written =
+        pwrite(state->fd, state->buffer, benchmark_buffer_size,
+               benchmark_offset(state->repetition));
+    if (written == -1) {
+        perror("pwrite");
+        exit(1);
+    }
+    assert(written == benchmark_buffer_size);
+
+    ++state->repetition;
+    if (state->repetition < benchmark_repetitions)
+        submit_pwrite_request(state);
+    else
+        ++completed;   // Wishing this is atomic.
+}

--- a/pwrite/c/libdispatch-channel-queue/Makefile
+++ b/pwrite/c/libdispatch-channel-queue/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/libdispatch-channel-queue/pwrite.c
+++ b/pwrite/c/libdispatch-channel-queue/pwrite.c
@@ -1,0 +1,81 @@
+#include <assert.h>
+#include <dispatch/dispatch.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    dispatch_data_t data;
+    dispatch_io_t channel;
+    int repetition;
+} per_file;
+
+int completed = 0;
+uint64_t start;
+
+void submit_pwrite_request(per_file *state);
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        char *buffer = benchmark_malloc(benchmark_buffer_size);
+        state[thread].data =
+            dispatch_data_create(buffer, benchmark_buffer_size, NULL,
+                                 DISPATCH_DATA_DESTRUCTOR_FREE);
+
+        // Using an intermediate fd because dispatch_io_create_with_path does
+        // not support relative paths.
+        int fd =
+            open(benchmark_file(thread), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        state[thread].channel =
+            dispatch_io_create(DISPATCH_IO_RANDOM, fd,
+                               dispatch_get_main_queue(), ^(int errno_) {
+                if (errno_ != 0) {
+                    errno = errno_;
+                    perror("dispatch_io_create");
+                    exit(1);
+                }
+            });
+
+        state[thread].repetition = 0;
+    }
+
+    start = mach_absolute_time();
+
+    for (int thread = 0; thread < benchmark_concurrency; ++thread)
+        submit_pwrite_request(&state[thread]);
+
+    dispatch_main();
+
+    // This should be unreachable.
+    return 0;
+}
+
+void submit_pwrite_request(per_file *state) {
+    dispatch_io_write(state->channel, benchmark_offset(state->repetition),
+                      state->data, dispatch_get_main_queue(),
+                      ^(bool done, dispatch_data_t remaining, int errno_) {
+        if (errno_ != 0) {
+            errno = errno_;
+            perror("dispatch_io_write");
+            exit(1);
+        }
+        assert(done);
+        assert(remaining == NULL);
+
+        ++state->repetition;
+        if (state->repetition < benchmark_repetitions)
+            submit_pwrite_request(state);
+        else {
+            ++completed;
+            if (completed >= benchmark_concurrency) {
+                uint64_t end = mach_absolute_time();
+                benchmark_show_result(start, end);
+                exit(0);
+            }
+        }
+    });
+}

--- a/pwrite/c/libdispatch-channel/Makefile
+++ b/pwrite/c/libdispatch-channel/Makefile
@@ -1,13 +1,1 @@
-.PHONY: all run clean
-
-all: pwrite
-
-pwrite: pwrite.c ../benchmark_osx_pwrite.h
-	cc -o pwrite pwrite.c
-
-run:
-	@echo `pwd`
-	@./pwrite
-
-clean:
-	rm -f pwrite
+../Makefile.system

--- a/pwrite/c/libdispatch-channel/Makefile
+++ b/pwrite/c/libdispatch-channel/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/libdispatch-channel/pwrite.c
+++ b/pwrite/c/libdispatch-channel/pwrite.c
@@ -1,0 +1,81 @@
+#include <assert.h>
+#include <dispatch/dispatch.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    dispatch_data_t data;
+    dispatch_io_t channel;
+    int repetition;
+} per_file;
+
+dispatch_queue_t queue;
+int completed = 0;
+
+void submit_pwrite_request(per_file *state);
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    queue = dispatch_queue_create("benchmark", DISPATCH_QUEUE_CONCURRENT);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        char *buffer = benchmark_malloc(benchmark_buffer_size);
+        state[thread].data =
+            dispatch_data_create(buffer, benchmark_buffer_size, NULL,
+                                 DISPATCH_DATA_DESTRUCTOR_FREE);
+
+        // Using an intermediate fd because dispatch_io_create_with_path does
+        // not support relative paths.
+        int fd =
+            open(benchmark_file(thread), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        state[thread].channel =
+            dispatch_io_create(DISPATCH_IO_RANDOM, fd, queue, ^(int errno_) {
+                if (errno_ != 0) {
+                    errno = errno_;
+                    perror("dispatch_io_create");
+                    exit(1);
+                }
+            });
+
+        state[thread].repetition = 0;
+    }
+
+    uint64_t start = mach_absolute_time();
+
+    for (int thread = 0; thread < benchmark_concurrency; ++thread)
+        submit_pwrite_request(&state[thread]);
+
+    // This is not a legitimate way to wait for the work to complete, but it is
+    // simple and works.
+    while (completed < benchmark_concurrency)
+        continue;
+
+    uint64_t end = mach_absolute_time();
+    benchmark_show_result(start, end);
+
+    return 0;
+}
+
+void submit_pwrite_request(per_file *state) {
+    dispatch_io_write(state->channel, benchmark_offset(state->repetition),
+                      state->data, queue,
+                      ^(bool done, dispatch_data_t remaining, int errno_) {
+        if (errno_ != 0) {
+            errno = errno_;
+            perror("dispatch_io_write");
+            exit(1);
+        }
+        assert(done);
+        assert(remaining == NULL);
+
+        ++state->repetition;
+        if (state->repetition < benchmark_repetitions)
+            submit_pwrite_request(state);
+        else
+            ++completed;   // Please atomic...
+    });
+}

--- a/pwrite/c/libuv/Makefile
+++ b/pwrite/c/libuv/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc `pkg-config --cflags --libs libuv` -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/libuv/pwrite.c
+++ b/pwrite/c/libuv/pwrite.c
@@ -1,0 +1,83 @@
+#include <assert.h>
+#include <uv.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    uv_buf_t buffer;
+    uv_file fd;
+    uv_fs_t request;
+    int repetition;
+} per_file;
+
+void submit_pwrite_request(uv_fs_t *request);
+void pwrite_callback(uv_fs_t *request);
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    setenv("UV_THREADPOOL_SIZE", "128", 0);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        state[thread].buffer.base = benchmark_malloc(benchmark_buffer_size);
+        state[thread].buffer.len = benchmark_buffer_size;
+
+        uv_fs_t open_request;
+        state[thread].fd =
+            uv_fs_open(NULL, &open_request, benchmark_file(thread),
+                       O_WRONLY | O_CREAT | O_TRUNC, 0644, NULL);
+        if (state[thread].fd < 0) {
+            fprintf(stderr, "Failed: uv_fs_open: %s\n",
+                    uv_strerror(state[thread].fd));
+            exit(1);
+        }
+        uv_fs_req_cleanup(&open_request);
+
+        state[thread].request.data = &state[thread];
+        state[thread].repetition = 0;
+    }
+
+    uint64_t start = mach_absolute_time();
+
+    for (int thread = 0; thread < benchmark_concurrency; ++thread)
+        submit_pwrite_request(&state[thread].request);
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+    uint64_t end = mach_absolute_time();
+    benchmark_show_result(start, end);
+
+    return 0;
+}
+
+void submit_pwrite_request(uv_fs_t *request) {
+    per_file *state = (per_file*)request->data;
+
+    int result =
+        uv_fs_write(uv_default_loop(), request, state->fd, &state->buffer, 1,
+                    benchmark_offset(state->repetition), pwrite_callback);
+    if (result != 0) {
+        // If the result is not zero, the request was not submitted.
+        fprintf(stderr, "Failed: uv_fs_write: %s\n", uv_strerror(result));
+        exit(1);
+    }
+}
+
+void pwrite_callback(uv_fs_t *request) {
+    if (request->result < 0) {
+        fprintf(stderr, "Failed: uv_fs_write: %s\n",
+                uv_strerror(request->result));
+        exit(1);
+    }
+    assert(request->result == benchmark_buffer_size);
+
+    uv_fs_req_cleanup(request);
+
+    per_file *state = (per_file*)request->data;
+
+    ++state->repetition;
+    if (state->repetition < benchmark_repetitions)
+        submit_pwrite_request(request);
+}

--- a/pwrite/c/pthread-parallel/Makefile
+++ b/pwrite/c/pthread-parallel/Makefile
@@ -1,13 +1,1 @@
-.PHONY: all run clean
-
-all: pwrite
-
-pwrite: pwrite.c ../benchmark_osx_pwrite.h
-	cc -o pwrite pwrite.c
-
-run:
-	@echo `pwd`
-	@./pwrite
-
-clean:
-	rm -f pwrite
+../Makefile.system

--- a/pwrite/c/pthread-parallel/Makefile
+++ b/pwrite/c/pthread-parallel/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/pthread-parallel/pwrite.c
+++ b/pwrite/c/pthread-parallel/pwrite.c
@@ -1,0 +1,88 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    char *buffer;
+    int fd;
+    pthread_t thread;
+} per_file;
+
+void pwrite_thread(per_file *state);
+typedef void* (*thread_routine)(void*);
+
+bool begin = false;
+pthread_cond_t begin_condition;
+pthread_mutex_t begin_mutex;
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    pthread_cond_init(&begin_condition, NULL);
+    pthread_mutex_init(&begin_mutex, NULL);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        state[thread].buffer = benchmark_malloc(benchmark_buffer_size);
+
+        state[thread].fd =
+            open(benchmark_file(thread), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (state[thread].fd == -1) {
+            perror("fopen");
+            exit(1);
+        }
+
+        int result =
+            pthread_create(&state[thread].thread, NULL,
+                           (thread_routine)pwrite_thread, &state[thread]);
+        if (result != 0) {
+            errno = result;
+            perror("pthread_create");
+            exit(1);
+        }
+    }
+
+    uint64_t start = mach_absolute_time();
+
+    pthread_mutex_lock(&begin_mutex);
+    begin = true;
+    pthread_cond_broadcast(&begin_condition);
+    pthread_mutex_unlock(&begin_mutex);
+
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        int result = pthread_join(state[thread].thread, NULL);
+        if (result != 0) {
+            errno = result;
+            perror("pthread_join");
+            exit(1);
+        }
+    }
+
+    uint64_t end = mach_absolute_time();
+    benchmark_show_result(start, end);
+
+    return 0;
+}
+
+void pwrite_thread(per_file *state) {
+    pthread_mutex_lock(&begin_mutex);
+    while (!begin)
+        pthread_cond_wait(&begin_condition, &begin_mutex);
+    pthread_mutex_unlock(&begin_mutex);
+
+    for (int repetition = 0; repetition < benchmark_repetitions; ++repetition) {
+        ssize_t written =
+            pwrite(state->fd, state->buffer, benchmark_buffer_size,
+                   benchmark_offset(repetition));
+        if (written == -1) {
+            perror("pwrite");
+            exit(1);
+        }
+        assert(written == benchmark_buffer_size);
+    }
+}

--- a/pwrite/c/pthread-queue/Makefile
+++ b/pwrite/c/pthread-queue/Makefile
@@ -1,13 +1,1 @@
-.PHONY: all run clean
-
-all: pwrite
-
-pwrite: pwrite.c ../benchmark_osx_pwrite.h
-	cc -o pwrite pwrite.c
-
-run:
-	@echo `pwd`
-	@./pwrite
-
-clean:
-	rm -f pwrite
+../Makefile.system

--- a/pwrite/c/pthread-queue/Makefile
+++ b/pwrite/c/pthread-queue/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all run clean
+
+all: pwrite
+
+pwrite: pwrite.c ../benchmark_osx_pwrite.h
+	cc -o pwrite pwrite.c
+
+run:
+	@echo `pwd`
+	@./pwrite
+
+clean:
+	rm -f pwrite

--- a/pwrite/c/pthread-queue/pwrite.c
+++ b/pwrite/c/pthread-queue/pwrite.c
@@ -1,0 +1,105 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "../benchmark_osx_pwrite.h"
+
+// Buffers are "deallocated" and fds closed by process exit.
+typedef struct {
+    char *buffer;
+    int fd;
+    int repetition;
+    bool busy;
+    pthread_t thread;
+    pthread_cond_t wake;
+} per_file;
+
+void pwrite_thread(per_file *state);
+typedef void* (*thread_routine)(void*);
+
+int completed = 0;
+pthread_cond_t idle;
+pthread_mutex_t queue_mutex;
+
+int main(int argc, char **argv) {
+    benchmark_parameters(argc, argv);
+
+    pthread_cond_init(&idle, NULL);
+    pthread_mutex_init(&queue_mutex, NULL);
+
+    per_file *state =
+        benchmark_malloc(sizeof(per_file) * benchmark_concurrency);
+    for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+        state[thread].buffer = benchmark_malloc(benchmark_buffer_size);
+
+        state[thread].fd =
+            open(benchmark_file(thread), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (state[thread].fd == -1) {
+            perror("fopen");
+            exit(1);
+        }
+
+        state[thread].repetition = 0;
+        state[thread].busy = false;
+
+        int result =
+            pthread_create(&state[thread].thread, NULL,
+                           (thread_routine)pwrite_thread, &state[thread]);
+        if (result != 0) {
+            errno = result;
+            perror("pthread_create");
+            exit(1);
+        }
+
+        pthread_cond_init(&state[thread].wake, NULL);
+    }
+
+    uint64_t start = mach_absolute_time();
+
+    pthread_mutex_lock(&queue_mutex);
+    while (completed < benchmark_concurrency) {
+        for (int thread = 0; thread < benchmark_concurrency; ++thread) {
+            if (!state[thread].busy) {
+                state[thread].busy = true;
+                pthread_cond_signal(&state[thread].wake);
+            }
+        }
+        pthread_cond_wait(&idle, &queue_mutex);
+    }
+    pthread_mutex_unlock(&queue_mutex);
+
+    uint64_t end = mach_absolute_time();
+    benchmark_show_result(start, end);
+
+    return 0;
+}
+
+void pwrite_thread(per_file *state) {
+    pthread_mutex_lock(&queue_mutex);
+    while (true) {
+        while (!state->busy)
+            pthread_cond_wait(&state->wake, &queue_mutex);
+        pthread_mutex_unlock(&queue_mutex);
+
+        ssize_t written =
+            pwrite(state->fd, state->buffer, benchmark_buffer_size,
+                   benchmark_offset(state->repetition));
+        if (written == -1) {
+            perror("pwrite");
+            exit(1);
+        }
+        assert(written == benchmark_buffer_size);
+
+        ++state->repetition;
+        pthread_mutex_lock(&queue_mutex);
+        pthread_cond_signal(&idle);
+        if (state->repetition < benchmark_repetitions)
+            state->busy = false;
+        else {
+            ++completed;
+            pthread_mutex_unlock(&queue_mutex);
+            return;
+        }
+    }
+}


### PR DESCRIPTION
- `blocking` and `pthread-parallel` are "controls": `blocking` runs `pwrite` in series, even when concurrency is requested, and `pthread-parallel` runs N independent threads when concurrency is N.
- `libdispatch-block` schedules blocks (the Objective-C `^{}` stuff) on a concurrent libdispatch queue. Each block runs a `pwrite` call, then schedules another such block for the same fd.
- `pthread-queue` starts one thread per fd, but each one synchronizes with the main thread between `pwrite` calls.
- `libuv` uses libuv's thread pool.
- `libdispatch-channel` uses libdispatch's channel API, i.e. `dispatch_io_write`.
- See comments further down about `libdispatch-block-queue` and `libdispatch-channel-queue`.

Example results:

```
--buffer-size 1024 --repetitions 4096

BENCHMARK          THREADS: 1       2       4       8      16      32      64

blocking                   2.44    3.19    2.70    2.51    2.64    2.53    2.38
pthread-parallel           2.72    1.42    0.80    1.30    1.24    1.28    1.25

libdispatch-block          4.73    2.23    1.43    1.33    1.16    1.30    1.28
pthread-queue             14.10    9.51   14.55   13.63   12.45   11.89   11.79
libuv                     20.39   15.03   18.50   18.13   18.77   11.86   19.43
libdispatch-channel       39.57   22.05   16.20   15.92   15.93   16.41   15.61

libdispatch-block-queue   19.58   10.30    4.93    1.38    1.86    1.63    1.42
libdispatch-channel-queue 32.40   15.94   12.23   12.36   13.05   12.17   12.08
```

```
--buffer-size 4096 --repetitions 1024

BENCHMARK          THREADS: 1       2       4       8      16      32      64

blocking                   1.90    1.69    1.83    1.78    1.61    1.56    1.24
pthread-parallel           1.29    0.74    0.66    1.27    1.24    1.26    1.16

libdispatch-block          1.97    1.09    0.98    1.26    1.23    1.24    1.14
pthread-queue              4.10    3.07    4.02    3.83    3.34    3.19    3.24
libuv                      5.40    2.88    3.29    4.96    4.93    5.03    5.00
libdispatch-channel       12.26    6.57    5.43    5.21    5.35    5.27    5.24

libdispatch-block-queue    6.42    2.89    1.80    1.36    1.31    1.30    1.20
libdispatch-channel-queue  9.53    4.79    4.14    4.07    3.98    4.02    3.95
```

```
--buffer-size 16384 --repetitions 256

BENCHMARK          THREADS: 1       2       4       8      16      32      64

blocking                   0.72    0.51    0.79    0.63    0.70    0.75    0.60
pthread-parallel           0.54    0.32    0.18    0.35    0.28    0.30    0.29

libdispatch-block          0.91    0.40    0.33    0.34    0.29    0.28    0.29
pthread-queue              4.00    0.88    1.05    1.03    0.92    0.88    0.77
libuv                      2.32    1.32    1.37    1.30    1.39    1.34    1.38
libdispatch-channel        3.53    1.71    1.88    1.67    1.58    1.67    1.56

libdispatch-block-queue    2.65    0.79    0.50    0.37    0.28    0.30    0.30
libdispatch-channel-queue  2.66    1.39    1.18    1.19    1.12    1.20    1.09
```

`libdispatch-block` looks particularly good. I will probably do extra checks to make sure that benchmark is implemented correctly, especially given the surprising apparent result that `libdispatch-channel` is much slower, despite being specifically designed for I/O (whereas `libidspatch-block` is using the generic libdispatch API). It does *appear* to be running concurrently so far, though.
